### PR TITLE
Implement fill-in-the-gaps for input feeds

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -245,7 +245,7 @@ function optimizeRow(headers: string[], data: string[]): string[] {
   const genAttributes = genTemplateRow
     .replace(TEMPLATE_PROMPT, '')
     .split(SEPARATOR)
-    .map((x: string) => `${x.trim()}`);
+    .map((x: string) => x.trim());
 
   const genTemplate = genAttributes
     .map((x: string) => `<${x.trim()}>`)
@@ -253,7 +253,8 @@ function optimizeRow(headers: string[], data: string[]): string[] {
 
   const origAttributes = origTemplateRow
     .replace(ORIGINAL_TITLE_TEMPLATE_PROMPT, '')
-    .split(SEPARATOR);
+    .split(SEPARATOR)
+    .map((x: string) => x.trim());
 
   const origTemplate = origAttributes
     .map((x: string) => `<${x.trim()}>`)
@@ -266,10 +267,15 @@ function optimizeRow(headers: string[], data: string[]): string[] {
 
   // Collect all title features with priority on user provided data
   // (use generated only when user provided data is not available)
-  const titleFeatures = genAttributes.map(
-    (attribute: string, index: number) =>
-      dataObj[attribute] || genAttributeValues[index]
-  );
+  const titleFeatures: string[] = [];
+  const gapAttributesAndValues: Record<string, string> = {};
+
+  genAttributes.forEach((attribute: string, index: number) => {
+    if (!dataObj[attribute]) {
+      gapAttributesAndValues[attribute] = genAttributeValues[index];
+    }
+    titleFeatures.push(dataObj[attribute] || genAttributeValues[index]);
+  });
 
   // create title solely based on titleFeatures to reduce hallucination potential
   const genTitle = titleFeatures.join(' ');
@@ -293,6 +299,9 @@ function optimizeRow(headers: string[], data: string[]): string[] {
   row[CONFIG.sheets.generated.cols.id] = itemId;
   row[CONFIG.sheets.generated.cols.titleOriginal] = origTitle;
   row[CONFIG.sheets.generated.cols.titleGenerated] = genTitle;
+  row[CONFIG.sheets.generated.cols.gapAttributes] = JSON.stringify(
+    gapAttributesAndValues
+  );
 
   return [
     ...row,
@@ -434,7 +443,7 @@ function writeGeneratedRows(rows: string[][], withHeader = false) {
 function getApprovedData() {
   return SheetsService.getInstance().getRangeData(
     CONFIG.sheets.output.name,
-    CONFIG.sheets.output.startRow + 1,
+    CONFIG.sheets.output.startRow,
     1
   );
 }
@@ -444,8 +453,14 @@ function getApprovedData() {
  *
  * @param {string[][]} rows
  */
-function writeApprovedRows(rows: string[][]) {
-  MultiLogger.getInstance().log('Writing approved rows...');
+function writeApprovedData(header: string[], rows: string[][]) {
+  MultiLogger.getInstance().log('Writing approved data...');
+  SheetsService.getInstance().setValuesInDefinedRange(
+    CONFIG.sheets.output.name,
+    CONFIG.sheets.output.startRow,
+    CONFIG.sheets.output.cols.gapCols.start + 1,
+    [header]
+  );
   SheetsService.getInstance().setValuesInDefinedRange(
     CONFIG.sheets.output.name,
     CONFIG.sheets.output.startRow + 1,
@@ -457,8 +472,13 @@ function writeApprovedRows(rows: string[][]) {
 /**
  * Clear all data rows from 'Supplemental Feed' sheet.
  */
-function clearApprovedRows() {
-  MultiLogger.getInstance().log('Clearing approved rows...');
+function clearApprovedData() {
+  MultiLogger.getInstance().log('Clearing approved data...');
+  SheetsService.getInstance().clearDefinedRange(
+    CONFIG.sheets.output.name,
+    CONFIG.sheets.output.startRow,
+    CONFIG.sheets.output.cols.gapCols.start + 1
+  );
   SheetsService.getInstance().clearDefinedRange(
     CONFIG.sheets.output.name,
     CONFIG.sheets.output.startRow + 1,
@@ -515,7 +535,7 @@ export function approveFiltered() {
 }
 
 /**
- * Merge title and description from 'FeedGen' to 'Approved' sheet.
+ * Merge title and other attributes from 'FeedGen' to 'Approved' sheet.
  */
 export function exportApproved() {
   MultiLogger.getInstance().log('Exporting approved rows...');
@@ -525,17 +545,30 @@ export function exportApproved() {
     return row[CONFIG.sheets.generated.cols.approval] === true;
   });
 
+  const filledInGapAttributes = [
+    ...new Set(
+      feedGenRows
+        .map(row =>
+          Object.keys(
+            JSON.parse(row[CONFIG.sheets.generated.cols.gapAttributes])
+          )
+        )
+        .flat(1)
+    ),
+  ];
+
   // Load 'Approved' sheet
   const approvedRows = getApprovedData();
-
-  // Generate id-keyed object from approved rows
-  const approvedRowsMap = arrayToMap(
-    approvedRows,
-    CONFIG.sheets.output.cols.id
+  let approvedColumnHeader = approvedRows.shift();
+  approvedColumnHeader = approvedColumnHeader?.slice(
+    CONFIG.sheets.output.cols.gapCols.start,
+    approvedColumnHeader.length
   );
+  approvedColumnHeader = [
+    ...new Set([...approvedColumnHeader!, ...filledInGapAttributes]),
+  ];
 
-  const feedGenApprovedRowsMap: Record<string, string[]> = {};
-
+  const rowsToWrite: string[][] = [];
   // Process rows
   for (const row of feedGenRows) {
     // Row container
@@ -550,35 +583,28 @@ export function exportApproved() {
         ? row[CONFIG.sheets.generated.cols.titleGenerated]
         : row[CONFIG.sheets.generated.cols.titleOriginal];
 
-    feedGenApprovedRowsMap[row[CONFIG.sheets.generated.cols.id]] = resRow;
-  }
+    const gapAttributesAndValues = JSON.parse(
+      row[CONFIG.sheets.generated.cols.gapAttributes]
+    );
+    const gapAttributesKeys = Object.keys(gapAttributesAndValues);
+    const originalInput = JSON.parse(
+      row[CONFIG.sheets.generated.cols.originalInput]
+    );
 
-  // Merge with 'Approved' rows
-  const merged = Object.values(
-    Object.assign(approvedRowsMap, feedGenApprovedRowsMap)
-  );
+    filledInGapAttributes.forEach(
+      (attribute, index) =>
+        (resRow[CONFIG.sheets.output.cols.gapCols.start + index] =
+          gapAttributesKeys.includes(attribute)
+            ? gapAttributesAndValues[attribute]
+            : originalInput[attribute])
+    );
+
+    rowsToWrite.push(resRow);
+  }
 
   // Clear 'Approved' sheet
-  clearApprovedRows();
+  clearApprovedData();
 
   // Write to 'Approved' sheet
-  writeApprovedRows(merged);
-}
-
-/**
- * Create map from array with key column.
- * @param {Array<Array<string>>} arr
- * @param {number} keyCol
- * @returns {Record<string, Array<string>>}
- */
-export function arrayToMap(arr: string[][], keyCol: number) {
-  const map: Record<string, string[]> = {};
-
-  for (const row of arr) {
-    if (!row[keyCol]) continue;
-
-    map[row[keyCol]] = row;
-  }
-
-  return map;
+  writeApprovedData(approvedColumnHeader, rowsToWrite);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,13 +47,15 @@ export const CONFIG = {
     },
     generated: {
       name: 'Generated Title Validation',
-      startRow: 1,
+      startRow: 5,
       cols: {
         approval: 0,
         status: 1,
         id: 2,
         titleOriginal: 3,
         titleGenerated: 4,
+        gapAttributes: 5,
+        originalInput: 22,
       },
     },
     output: {
@@ -62,6 +64,9 @@ export const CONFIG = {
       cols: {
         id: 0,
         title: 1,
+        gapCols: {
+          start: 2,
+        },
       },
     },
     log: {


### PR DESCRIPTION
Implemented the following:
- Kept track of attributes that were missing in the input feed and got generated (and used) for generated titles
- Added those modified attributes upon "exporting approved items" to the output feed, to be used with MC supplemental feeds
  -  Since modified attributed might be different across different items (e.g. one item had a missing color, the other a missing brand name), the "export" operation uses the value of the generated attribute if modified otherwise the original attribute.
- Removed the existing "merge" logic for the output feed (as it is no longer needed)