### PR TITLE
Implement fill-in-the-gaps for input feeds

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -531,17 +531,6 @@ export function exportApproved() {
     ),
   ];
 
-  // Load 'Approved' sheet
-  const approvedRows = getApprovedData();
-  let approvedColumnHeader = approvedRows.shift();
-  approvedColumnHeader = approvedColumnHeader?.slice(
-    CONFIG.sheets.output.cols.gapCols.start,
-    approvedColumnHeader.length
-  );
-  approvedColumnHeader = [
-    ...new Set([...approvedColumnHeader!, ...filledInGapAttributes]),
-  ];
-
   const rowsToWrite: string[][] = [];
   // Process rows
   for (const row of feedGenRows) {
@@ -583,5 +572,5 @@ export function exportApproved() {
   clearApprovedData();
 
   // Write to 'Approved' sheet
-  writeApprovedData(approvedColumnHeader, rowsToWrite);
+  writeApprovedData(filledInGapAttributes, rowsToWrite);
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,10 +70,6 @@ export function onOpen() {
     .addToUi();
 }
 
-function logSummary() {
-  MultiLogger.getInstance().log('Summary: ');
-}
-
 /**
  * Open sidebar.
  */
@@ -224,13 +220,8 @@ function optimizeRow(
   // Generate title with all available context
   const res = generateTitle(dataObj);
 
-  const [
-    origTemplateRow,
-    genCategoryRow,
-    genTemplateRow,
-    genAttributesRow,
-    genTitleRow,
-  ] = res.split('\n');
+  const [origTemplateRow, genCategoryRow, genTemplateRow, genAttributesRow] =
+    res.split('\n');
 
   const genCategory = genCategoryRow.replace(CATEGORY_PROMPT, '').trim();
 
@@ -406,19 +397,6 @@ function writeGeneratedRows(rows: string[][], withHeader = false) {
     CONFIG.sheets.generated.startRow + offset,
     1,
     rows
-  );
-}
-
-/**
- * Get rows from 'Supplemental Feed' sheet.
- *
- * @returns {string[][]}
- */
-function getApprovedData() {
-  return SheetsService.getInstance().getRangeData(
-    CONFIG.sheets.output.name,
-    CONFIG.sheets.output.startRow,
-    1
   );
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,8 @@ export const CONFIG = {
         id: 2,
         titleOriginal: 3,
         titleGenerated: 4,
+        gapAttributes: 10,
+        originalInput: 12,
       },
     },
     output: {
@@ -62,6 +64,10 @@ export const CONFIG = {
       cols: {
         id: 0,
         title: 1,
+        modificationTimestamp: 2,
+        gapCols: {
+          start: 3,
+        },
       },
     },
     log: {


### PR DESCRIPTION
Implemented the following:

- Kept track of attributes that were missing in the input feed and got generated (and used) for generated titles
- Added those modified attributes upon "exporting approved items" to the output feed, to be used with MC supplemental feeds
  - Since modified attributed might be different across different items (e.g. one item had a missing color, the other a missing brand name), the "export" operation uses the value of the generated attribute if modified otherwise the original attribute.
- Removed the existing "merge" logic for the output feed (as it is no longer needed)