### PR TITLE
Fix generation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -329,7 +329,7 @@ function findRowIndex(
   if (!sheet) {
     throw new Error(`Sheet ${sheetName} not found`);
   }
-  if (sheet.getLastRow() - offset === 0) {
+  if (sheet.getLastRow() - offset + 1 === 0) {
     return 0;
   }
   const range = sheet?.getRange(

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,7 +86,7 @@ function findRowIndex(
     throw new Error(`Sheet ${sheetName} not found`);
   }
 
-  if (sheet.getLastRow() - offset === 0) {
+  if (sheet.getLastRow() - offset + 1 === 0) {
     return 0;
   }
 


### PR DESCRIPTION
Fixed 'number of rows in the range must be at least 1' by adjusting the catching condition which checks if there are no generated rows.