### PR TITLE
Switch Client <-> Server communication to JSON

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -451,7 +451,7 @@ function getUnprocessedInputRows(filterProcessed) {
       row => !generatedRowIds.includes(String(row[itemIdIndex]))
     );
   }
-  return inputRows;
+  return JSON.stringify(inputRows);
 }
 function generateRow(headers, row) {
   const rowIndex = Number(row.pop());

--- a/dist/static/index.html
+++ b/dist/static/index.html
@@ -200,7 +200,7 @@ limitations under the License.
       }
       const unprocessedInputRows = await new Promise((resolve, reject) => {
         google.script.run
-          .withSuccessHandler(res => resolve(res))
+          .withSuccessHandler(rowsString => resolve(JSON.parse(rowsString)))
           .withFailureHandler(err => log(err))
           .getUnprocessedInputRows(resume);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -109,7 +109,9 @@ export function FEEDGEN_CREATE_JSON_CONTEXT_FOR_ITEM(itemId: string) {
  * Fetch all unprocessed rows, optionally filtering out already processed ones.
  *
  * @param filterProcessed Whether to filter processed rows or not.
- * @returns All unprocessed rows, with or without already processed ones.
+ * @returns JSON string corresponding to all unprocessed rows, with or without
+ *     already processed ones. Needs to be a JSON string as Apps Script may end
+ *     up nullifying the array if it contained a non-primitive data type.
  */
 export function getUnprocessedInputRows(filterProcessed: boolean) {
   const inputSheet = SpreadsheetApp.getActive().getSheetByName(
@@ -143,7 +145,7 @@ export function getUnprocessedInputRows(filterProcessed: boolean) {
       row => !generatedRowIds.includes(String(row[itemIdIndex]))
     );
   }
-  return inputRows;
+  return JSON.stringify(inputRows);
 }
 
 /**

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -200,7 +200,7 @@ limitations under the License.
       }
       const unprocessedInputRows = await new Promise((resolve, reject) => {
         google.script.run
-          .withSuccessHandler(res => resolve(res))
+          .withSuccessHandler(rowsString => resolve(JSON.parse(rowsString)))
           .withFailureHandler(err => log(err))
           .getUnprocessedInputRows(resume);
       });


### PR DESCRIPTION
This prevents Apps Script from erroneously nullifying arrays which contain non-primitive data types.