### PR TITLE
Fix undefined being output for some generated attributes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -121,6 +121,7 @@ export const CONFIG = {
         descriptionGenerated: 4,
         gapAttributes: 12,
         originalInput: 13,
+        fullApiResponse: 16,
       },
     },
     output: {

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,5 +1,3 @@
-import { MultiLogger } from './logger';
-
 /**
  * Copyright 2023 Google LLC
  *
@@ -23,16 +21,15 @@ export class Util {
       try {
         return fn();
       } catch (err) {
-        const error = err as Error;
-        MultiLogger.getInstance().log(`Error: ${error.message}`);
-        retryCount++;
         if (delayMillies) {
           Utilities.sleep(delayMillies);
         }
+        retryCount++;
+        if (retryCount === maxRetries) {
+          throw err;
+        }
       }
     }
-
-    throw new Error(`Exceeded maximum number of retries (${maxRetries}).`);
   }
 
   static splitWords(text: string) {

--- a/src/helpers/vertex.ts
+++ b/src/helpers/vertex.ts
@@ -95,9 +95,11 @@ export class VertexHelper {
     MultiLogger.getInstance().log(res);
 
     if (res.predictions[0].safetyAttributes.blocked) {
-      throw new Error('Blocked for safety reasons.');
+      throw new Error(
+        `Request was blocked as it triggered API safety filters. Prompt: ${prompt}`
+      );
     } else if (!res.predictions[0].content) {
-      throw new Error('No content');
+      throw new Error(`Received empty response from API. Prompt: ${prompt}`);
     }
 
     return res.predictions[0].content;


### PR DESCRIPTION
This happens if the API responded with an attribute key in the "template" response but no associated value in the "attribute values" response (potential bigger change: have the API respond directly with key-value pairs instead of separate rows for "keys" and "values").

Both the "template" and the "generated title" have now been corrected to remove the empty-value attribute appearing in the "template", and "undefined" appearing in the title.

This change also includes removing unnecessary logging and writes error output into the Full API response column (as the "log" sheet is hidden by default, and it's difficult to find the corresponding entry as we don't log with any row information like Item ID for example).